### PR TITLE
update node-fetch to version 2

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -57,7 +57,7 @@ function registry({cwd, url, timeout = 5000}) {
       .then(resp => {
         const {status, statusText, ok} = resp;
         result = {status, statusText, ok};
-        return ok ? resp.json() : result;
+        return ok ? (resp.status === 204 ? {} : resp.json()) : result;
       })
       .then(meta => Object.assign(result, {
         latest: getLatest(meta),

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "ini": "~1.3.0",
     "minimatch": "~3.0.0",
-    "node-fetch": "~1.7.0",
+    "node-fetch": "^2.0.0",
     "semver": "~5.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates node-fetch to version 2.

A review of the code indicates that no other parts are affected by the breaking changes in the library update.